### PR TITLE
Landing: Use on-chain NFT-Metadata

### DIFF
--- a/components/landing/LostCardView.js
+++ b/components/landing/LostCardView.js
@@ -5,7 +5,7 @@ import { WalletAddress } from '@/components/landing'
 // TODO: Replace with correct icon or animation
 import receivingNFTAnimation from "@/lib/receivingNFT.json";
 
-const LostCardView = ({ nft, wallet, newOwner, ...props}) => {
+const LostCardView = ({ wallet, newOwner, ...props}) => {
 	return (
 		<div className="flex flex-col">
 			<div className="flex flex-col justify-center text-center mx-5">

--- a/components/landing/NFTImage.js
+++ b/components/landing/NFTImage.js
@@ -1,0 +1,35 @@
+import React, { useState, useEffect } from 'react';
+
+const NFTImage = ({ assetData, ...props }) => {
+  const [imageUrl, setImageUrl] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    // Immediately invoked async function inside the useEffect
+    (async () => {
+      setIsLoading(true);
+      try {
+        const response = await fetch(assetData.token_uri);
+        if (!response.ok) {
+          throw new Error(`HTTP error! Status: ${response.status}`);
+        }
+        const metadata = await response.json();
+        setImageUrl(metadata.image);
+      } catch (e) {
+        console.error("Fetching NFT metadata failed", e);
+        setError(e.message);
+      } finally {
+        setIsLoading(false);
+      }
+    })();
+  }, [assetData.token_uri]); // Run this effect only when token_uri changes
+
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error loading image: {error}</div>;
+
+  // If we have an image URL, render it
+  return imageUrl ? <a href={assetData.links.opensea}><img src={imageUrl} alt="NFT" {...props} /></a> : null;
+};
+
+export default NFTImage;

--- a/components/landing/NFTLinks.js
+++ b/components/landing/NFTLinks.js
@@ -1,0 +1,9 @@
+const NFTLinks = ({assetData, ...props}) => (
+	<div className="flex items-center overflow-auto w-full font-mono p-2 rounded text-white mt-5">
+		<span>
+            {assetData.links.opensea ? <a href={assetData.links.opensea}>View on OpenSea</a> : ""}
+		</span>
+	</div>
+)
+
+export default NFTLinks

--- a/components/landing/OwnerCardView.js
+++ b/components/landing/OwnerCardView.js
@@ -1,64 +1,18 @@
 import React, { useCallback } from 'react'
-import { WalletAddress } from '@/components/landing'
+import { NFTLinks, WalletAddress } from '@/components/landing'
+import { NFTImage } from '@/components/landing'
 import { formatAddress } from '@/lib/utils'
 
-const OwnerCardView = ({ nft, wallet, ...props}) => {
-	const Description = useCallback(() => {
-		return (
-			<div className="collapse collapse-arrow rounded-lg bg-[#dfdfdf] text-[#505157]">
-				<input type="checkbox" className="min-h-[0.75rem]" />
-				<div className="collapse-title py-2 min-h-[0.75rem] text-xl font-medium">
-					Description
-				</div>
-				<div className="collapse-content">
-					<p>{nft.metadata.description}</p>
-				</div>
-			</div>
-		)
-	}, [nft])
-
-	const Traits = useCallback(() => {
-		return (
-			<div className="collapse collapse-arrow rounded-lg bg-[#dfdfdf] text-[#505157] mt-6">
-				<input type="checkbox" className="min-h-[0.75rem]" />
-				<div className="collapse-title py-2 min-h-[0.75rem] text-xl font-medium">
-					Traits
-				</div>
-				<div className="collapse-content">
-					{nft.metadata.attributes.length > 0 && (
-						<ul>
-							{nft.metadata.attributes.map((prop, index) => (
-								Object.keys(prop).map((item, itemIndex) => (
-									<li key={itemIndex}>
-										{item}: {prop[item]}
-									</li>
-								))
-							))}
-						</ul>
-					)}
-
-					{nft.metadata.attributes.length == 0 && (
-						<span>There is no attributes defined for this NFT</span>
-					)}
-				</div>
-			</div>
-		)
-	}, [nft])
-
+const OwnerCardView = ({ wallet, assetData, ...props}) => {
 	return (
 		<div className="flex flex-col">
 			<div className="flex flex-col justify-center text-center mx-5">
-				<img src="https://placehold.co/600x400/EEE/31343C" />
+				<NFTImage assetData={assetData} />
+				<NFTLinks assetData={assetData} />
 				<WalletAddress address={wallet.address} />
 			</div>
-
 			<div className="text-slate-700 text-center justify-center">
 				owning wallet
-			</div>
-
-			<div className="flex flex-col mt-8">
-				<Description />
-				<Traits />
 			</div>
 		</div>
 	)

--- a/components/landing/ReceivingCardView.js
+++ b/components/landing/ReceivingCardView.js
@@ -3,7 +3,7 @@ import Lottie from "lottie-react";
 import { WalletAddress } from '@/components/landing'
 import receivingNFTAnimation from "@/lib/receivingNFT.json";
 
-const ReceivingCardView = ({ nft, wallet, assetData, ...props}) => {
+const ReceivingCardView = ({ wallet, assetData, ...props}) => {
 	return (
 		<div className="flex flex-col">
 			<div className="flex flex-col justify-center text-center mx-5">

--- a/components/landing/index.js
+++ b/components/landing/index.js
@@ -3,11 +3,15 @@ import OwnerCardView from './OwnerCardView'
 import ReceivingCardView from './ReceivingCardView'
 import LostCardView from './LostCardView'
 import WalletAddress from './WalletAddress'
+import NFTImage from './NFTImage'
+import NFTLinks from './NFTLinks'
 
 export {
 	Layout,
 	LostCardView,
 	OwnerCardView,
 	WalletAddress,
-	ReceivingCardView
+	ReceivingCardView,
+	NFTImage,
+	NFTLinks
 }

--- a/pages/api/internal/contracts/index.js
+++ b/pages/api/internal/contracts/index.js
@@ -45,7 +45,8 @@ const storeContracts = async(signedContracts, wallet) => {
 					connect: {
 						id: wallet.id
 					}
-				}
+				},
+				settings: {} // Create empty settings
 			}
 		})
 

--- a/schema.prisma
+++ b/schema.prisma
@@ -40,8 +40,9 @@ model Contract {
   ownerId String @map(name: "owner_id")
   network String
 
-  createdAt DateTime @default(now()) @map(name: "created_at")
-  updatedAt DateTime @default(now()) @map(name: "updated_at")
+  /// Contract-Settings and configurations defining the behavior of endpoints and pages
+  settings Json
+
   nfts      NFT[]
   assets    Asset[]
 
@@ -49,6 +50,9 @@ model Contract {
   defaultNft  NFT?     @relation("DefaultNFT", fields: [defaultNftId], references: [id])
   defaultNftId String? @map(name: "default_nft_id") @unique
 
+  createdAt DateTime @default(now()) @map(name: "created_at")
+  updatedAt DateTime @default(now()) @map(name: "updated_at")
+  
   @@map(name: "contracts")
 }
 


### PR DESCRIPTION
On the landing page, the actual on-chain metadata shall be shown. This is fetched via an NFT's token_uri, which is available through the asset-by-sip endpoint.

This displays and fetches all data through the on-chain tokenURI, which is conveniently provided through metaanchor-api.

In many settings the instance displaying the landing page may also serve the metadata and NFT-Assets, but especially if IPFS or other customized settings are used, which overwrite on-chain TokenURI / baseURI, this breaks.

This also shows and embeds OpenSea links, which is provided by MetaAnchor-API v0.2.3 and newer