### PR TITLE
Collection-Settings: Token details

### DIFF
--- a/components/studio/EditableContractSettings.js
+++ b/components/studio/EditableContractSettings.js
@@ -1,6 +1,6 @@
 // EditableContractSettings.js
 import { useState, useEffect } from 'react';
-import { Button, Alert } from '../ui';
+import { Button, Tooltip, Alert } from '../ui';
 
 const EditableContractSettings = ({ wallet, contract, ...props }) => {
   const [nftName, setNftName] = useState(contract.settings?.NFT_NAME);
@@ -8,16 +8,12 @@ const EditableContractSettings = ({ wallet, contract, ...props }) => {
   const [success, setSuccess] = useState();
   const [error, setError] = useState()
 
+  const variableText = "Use [VARIABLE] to insert dynamic content. Supported variables: ANCHOR, ANCHOR_SHORT, CONTRACT_ADDRESS, COLLECTION_NAME, COLLECTION_NAME_SHORT"
+
   const onFinish = () => {
     setSuccess("Changes saved successfully");
     setTimeout(() => setSuccess(), 1500); // Hide alert after 3 second
   }
-
-  {error && (
-    <div className="mt-5">
-      <Alert text={error} type='error' />
-    </div>
-  )}
 
   const save = async (newSettings) => {
     try {
@@ -65,41 +61,42 @@ const EditableContractSettings = ({ wallet, contract, ...props }) => {
   }
 
   return (
-
     <div>
-      <div className="form-control w-full max-w-xs">
+      <div className="form-control w-full">
         <label className="label">
-          <span className="label-text">NFT Name Name</span>
+          <span className="label-text">NFT-Name</span>
+          <Tooltip text={`Added as 'name' to NFT metadata. ${variableText}`}><p>(?)</p></Tooltip>
         </label>
         <input type="text" value={nftName}
-          className="input input-bordered w-full max-w-xs"
+          className="input input-bordered w-full"
           onChange={(e) => setNftName(e.target.value)}
         />
       </div>
 
-      <div className="form-control w-full max-w-xs">
+      <div className="form-control w-full">
         <label className="label">
-          <span className="label-text">NFT Description</span>
+          <span className="label-text">NFT-Description</span>
+          <Tooltip text={`Added as 'descripton' to NFT metadata. ${variableText}`}><p>(?)</p></Tooltip>
         </label>
         <input type="text" value={nftDescription}
           onChange={(e) => setNftDescription(e.target.value)}
-          className="input input-bordered w-full max-w-xs" />
+          className="input input-bordered w-full" />
       </div>
 
       <button onClick={onSave} className="ml-2 btn btn-link text-white text-center">
         Save
       </button>
       {error && (
-				<div className="mt-5">
-					<Alert text={error} type='success' />
-				</div>
-			)}
+        <div className="mt-5">
+          <Alert text={error} type='success' />
+        </div>
+      )}
 
       {success && (
-				<div className="mt-5">
-					<Alert text={success} type='success' />
-				</div>
-			)}
+        <div className="mt-5">
+          <Alert text={success} type='success' />
+        </div>
+      )}
     </div>
   );
 }

--- a/components/studio/EditableContractSettings.js
+++ b/components/studio/EditableContractSettings.js
@@ -1,0 +1,107 @@
+// EditableContractSettings.js
+import { useState, useEffect } from 'react';
+import { Button, Alert } from '../ui';
+
+const EditableContractSettings = ({ wallet, contract, ...props }) => {
+  const [nftName, setNftName] = useState(contract.settings?.NFT_NAME);
+  const [nftDescription, setNftDescription] = useState(contract.settings?.NFT_DESCRIPTION);
+  const [success, setSuccess] = useState();
+  const [error, setError] = useState()
+
+  const onFinish = () => {
+    setSuccess("Changes saved successfully");
+    setTimeout(() => setSuccess(), 1500); // Hide alert after 3 second
+  }
+
+  {error && (
+    <div className="mt-5">
+      <Alert text={error} type='error' />
+    </div>
+  )}
+
+  const save = async (newSettings) => {
+    try {
+      const response = await fetch(`/api/internal/contract/${contract.csn}/edit`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          contractSettings: newSettings
+        }),
+      });
+
+      const data = await response.json()
+
+      if (response.ok) {
+        setError()
+        onFinish()
+      } else {
+        let errorMsg = data.message
+
+        if (data.issues) {
+          errorMsg = `${errorMsg} ${data.issues}`
+        }
+
+        setError(errorMsg)
+      }
+    } catch (error) {
+      console.error('Error: ', error);
+      setError('There was an error while trying to communicate with the API')
+    }
+  }
+
+  const onSave = async () => {
+    try {
+      let data = {
+        NFT_NAME: nftName,
+        NFT_DESCRIPTION: nftDescription
+      }
+
+      save(data)
+    } catch (error) {
+      setError('Unknown error')
+    }
+  }
+
+  return (
+
+    <div>
+      <div className="form-control w-full max-w-xs">
+        <label className="label">
+          <span className="label-text">NFT Name Name</span>
+        </label>
+        <input type="text" value={nftName}
+          className="input input-bordered w-full max-w-xs"
+          onChange={(e) => setNftName(e.target.value)}
+        />
+      </div>
+
+      <div className="form-control w-full max-w-xs">
+        <label className="label">
+          <span className="label-text">NFT Description</span>
+        </label>
+        <input type="text" value={nftDescription}
+          onChange={(e) => setNftDescription(e.target.value)}
+          className="input input-bordered w-full max-w-xs" />
+      </div>
+
+      <button onClick={onSave} className="ml-2 btn btn-link text-white text-center">
+        Save
+      </button>
+      {error && (
+				<div className="mt-5">
+					<Alert text={error} type='success' />
+				</div>
+			)}
+
+      {success && (
+				<div className="mt-5">
+					<Alert text={success} type='success' />
+				</div>
+			)}
+    </div>
+  );
+}
+
+export default EditableContractSettings

--- a/components/studio/index.js
+++ b/components/studio/index.js
@@ -8,6 +8,7 @@ import NFTImageUploader from './NFTImageUploader'
 import NFTCaption from './NFTCaption'
 import TraitsBox from './TraitsBox'
 import MetadataBox from './MetadataBox'
+import EditableContractSettings from './EditableContractSettings'
 
 export {
 	Header,
@@ -19,5 +20,6 @@ export {
 	MetadataBox,
 	NFTImageEdit,
 	NFTImageUploader,
-	NFTCaption
+	NFTCaption,
+	EditableContractSettings,
 }

--- a/components/ui/Tooltip.js
+++ b/components/ui/Tooltip.js
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+
+const Tooltip = ({ children, text }) => {
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  return (
+    <div
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
+      style={{ position: 'relative', display: 'inline-block' }}
+    >
+      {children}
+      {showTooltip && (
+        <div className="bg-shark-700" style={{
+          position: 'absolute',
+          bottom: '100%',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          padding: '5px',         
+          borderRadius: '4px',
+          textAlign: 'center',
+          fontSize: '12px',
+          zIndex: '1',
+          width: "500px"
+        }}>
+          {text}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default Tooltip

--- a/components/ui/index.js
+++ b/components/ui/index.js
@@ -8,6 +8,7 @@ import NavBarMenu from './NavBarMenu'
 import AppLayout from './AppLayout'
 import Sidebar from './Sidebar'
 import ErrorPage from './ErrorPage'
+import Tooltip from './Tooltip'
 
 export {
 	Logo,
@@ -20,4 +21,5 @@ export {
 	Sidebar,
 	ErrorPage,
 	NavBarMenu,
+	Tooltip,
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,3 +29,10 @@ export function generateMetaDataURL(nft) {
 export function pp(json) {
 	return JSON.stringify(json, null, 4);
 }
+
+// Pass "Duck [ANCHOR_SHORT]", {"ANCHOR_SHORT": "0x123..abc"} and it will return "Duck 0x123...abc"
+export function fillVariablesIntoString(text, variables) {
+    return text.replace(/\[([^\]]+)\]/g, function(_, variable) {
+        return variables[variable] || `[${variable}]`;
+    });
+}

--- a/pages/api/internal/contract/[csn]/edit.js
+++ b/pages/api/internal/contract/[csn]/edit.js
@@ -1,0 +1,62 @@
+import { getServerSession } from 'next-auth/next'
+import { authOptions } from '@/pages/api/auth/[...nextauth]'
+import prisma from '@/lib/prisma'
+
+const allowedMethods = ['PUT']
+
+export default async function handle(req, res) {
+	const session = await getServerSession(req, res, authOptions)
+	if (!session) {
+		return res.status(401).json({ message: 'Unauthorized' })
+	}
+
+	if (!allowedMethods.includes(req.method) || req.method == 'OPTIONS') {
+		return res.status(405).json({ message: 'Method not allowed.' })
+	}
+
+	const { csn } = req.query
+	const { contractSettings: rawContractSettings } = req.body
+	let contractSettings = rawContractSettings
+
+	if (typeof rawContractSettings == "string") {
+		try {
+			metadata = JSON.parse(rawContractSettings)
+		} catch (error) {
+			console.error(error)
+			return res.status(422).json({
+				message: 'JSON is either malformatted or not a JSON object'
+			})
+		}
+	}
+
+	const contract = await prisma.Contract.findFirst({
+		where: {
+			csn: csn,
+            owner: session.wallet_id	
+		}
+	})
+
+	if (!contract) {
+		return res.status(404).json({ message: 'Contract does not exist' })
+	}
+
+	try {
+		const updatedSettings = await prisma.Contract.update({
+			where: {
+				id: contract.id
+			},
+			data: {
+				settings: contractSettings,
+				updatedAt: new Date()
+			}
+		})
+
+		contract.settings = contractSettings
+	} catch (err) {
+		console.error(err)
+		return res.status(500).json({
+			message: 'There were some error when updating the contract settings',
+		})
+	}
+	return res.json({ ...contract })
+}

--- a/pages/studio/[csn]/settings.js
+++ b/pages/studio/[csn]/settings.js
@@ -2,12 +2,15 @@ import NextHead from 'next/head'
 import Link from 'next/link'
 
 import { AppLayout, Loading, ErrorPage } from '@/components/ui'
-import { DefaultContractNFTView, NFTCard } from '@/components/studio'
+import { NFTCard } from '@/components/studio'
+import { EditableContractSettings } from '@/components/studio'
+
 
 import { useSession } from 'next-auth/react'
 import { usePathname, useRouter } from 'next/navigation'
 import { getServerSession } from 'next-auth/next'
 import { auth } from 'auth'
+
 
 import prisma from '@/lib/prisma'
 import NFTView from './[anchor]'
@@ -38,7 +41,8 @@ export async function getServerSideProps(context) {
 		select: {
 			id: true,
 			name: true,
-			csn: true
+			csn: true,
+			settings: true,
 		}
 	})
 
@@ -60,8 +64,6 @@ export async function getServerSideProps(context) {
 			}
 		}
 	}
-
-
 
 	return {
 		props: {
@@ -127,8 +129,8 @@ const ContractConfig = ({ defaultNFT, wallet, contract, ...props }) => {
 											<span className="label-text">Contract Name</span>
 										</label>
 										<input type="text" placeholder={contract.name}
-												readOnly
-												className="input input-bordered w-full max-w-xs" />
+											readOnly
+											className="input input-bordered w-full max-w-xs" />
 									</div>
 
 									<div className="form-control w-full max-w-xs">
@@ -136,10 +138,12 @@ const ContractConfig = ({ defaultNFT, wallet, contract, ...props }) => {
 											<span className="label-text">Contract CSN</span>
 										</label>
 										<input type="text" placeholder={contract.csn}
-												readOnly
-												className="input input-bordered w-full max-w-xs" />
+											readOnly
+											className="input input-bordered w-full max-w-xs" />
 									</div>
+									<EditableContractSettings contract={contract} wallet={wallet} />
 								</div>
+
 
 								<div className="flex ml-8">
 									<NFTCard nft={defaultNFT} />

--- a/pages/studio/[csn]/settings.js
+++ b/pages/studio/[csn]/settings.js
@@ -4,16 +4,8 @@ import Link from 'next/link'
 import { AppLayout, Loading, ErrorPage } from '@/components/ui'
 import { NFTCard } from '@/components/studio'
 import { EditableContractSettings } from '@/components/studio'
-
-
-import { useSession } from 'next-auth/react'
-import { usePathname, useRouter } from 'next/navigation'
-import { getServerSession } from 'next-auth/next'
 import { auth } from 'auth'
-
-
 import prisma from '@/lib/prisma'
-import NFTView from './[anchor]'
 
 export async function getServerSideProps(context) {
 	const session = await auth(context.req, context.res)
@@ -76,20 +68,12 @@ export async function getServerSideProps(context) {
 }
 
 const ContractConfig = ({ defaultNFT, wallet, contract, ...props }) => {
-	const router = useRouter()
-	const pathname = usePathname()
-
 	if (props.forbidden) {
 		return (
 			<ErrorPage status={403} />
 		)
 	}
-
-	const onReplaceImage = () => {
-		router.replace(pathname)
-	}
-
-
+	
 	return (
 		<>
 			<NextHead>
@@ -100,7 +84,7 @@ const ContractConfig = ({ defaultNFT, wallet, contract, ...props }) => {
 					<main className="flex flex-col">
 						<span className="text-center w-full text-xl font-bold mt-5">
 							<div className="flex border-b border-raven-700">
-								<div className="flex w-full ml-8 mt-8">
+								<div className="flex w-full ml-8 mt-8 max-w-s">
 									<div className="flex flex-row justify-between items-center w-full pl-8 pb-8">
 										<div className="flex flex-col items-start">
 											<div className="text-gray-400 text-sm font-normal breadcrumbs">
@@ -123,23 +107,23 @@ const ContractConfig = ({ defaultNFT, wallet, contract, ...props }) => {
 							</div>
 
 							<div className="flex justify-between w-9/12 ml-8 mt-8 mb-8">
-								<div className="flex flex-col">
-									<div className="form-control w-full max-w-xs">
+								<div className="flex flex-col w-full">
+									<div className="form-control w-full">
 										<label className="label">
 											<span className="label-text">Contract Name</span>
 										</label>
 										<input type="text" placeholder={contract.name}
 											readOnly
-											className="input input-bordered w-full max-w-xs" />
+											className="input input-bordered w-full" />
 									</div>
 
-									<div className="form-control w-full max-w-xs">
+									<div className="form-control w-full ">
 										<label className="label">
 											<span className="label-text">Contract CSN</span>
 										</label>
 										<input type="text" placeholder={contract.csn}
 											readOnly
-											className="input input-bordered w-full max-w-xs" />
+											className="input input-bordered w-full" />
 									</div>
 									<EditableContractSettings contract={contract} wallet={wallet} />
 								</div>


### PR DESCRIPTION
This is rather a throw-away component, as everything is hardcoded and we need to generalize this better and will likely rework error-handling, Alerts etc. soon.

- It adds two text-fields NFT-Name and NFT-Description, which is parsed into an NFT's metadata. 
- If name and description are set on NFT-level, the contract-settings are overwritten.