### PR TITLE
docker: add health check and make web container wait for db

### DIFF
--- a/.db.env.sample
+++ b/.db.env.sample
@@ -2,5 +2,11 @@
 # customized/info on their docker hub page: https://hub.docker.com/_/postgres
 #
 # Remember, these must match the values specified on .env.local
+
+# This is simply because psql and pg_isready are two different (although
+# related) programs which have different logic of environment lookup (one looks
+# for POSTGRES_USER, the other one – for PGUSER).
+PGUSER=digitalsoul
 POSTGRES_USER=digitalsoul
 POSTGRES_PASSWORD=digitalsoul
+POSTGRES_DB=digitalsoul_dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,8 @@ services:
     ports:
       - "3000:3000"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     volumes:
       - .:/srv/app
       - /srv/app/.next
@@ -25,6 +26,11 @@ services:
 
   db:
     image: postgres:15-alpine
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     env_file:
       - .db.env
     volumes:


### PR DESCRIPTION
This also introduces a new environment variable, PGUSER which is used by `pg_isready` command. It'll also introduces the `POSTGRES_DB` which should point to the correct DB being used in each environment (_dev on development environments, _production in production environments, etc)