### PR TITLE
Add nft.private_data and variable-access

### DIFF
--- a/__tests__/api/v1/collections/index.test.js
+++ b/__tests__/api/v1/collections/index.test.js
@@ -96,4 +96,73 @@ describe('/api/v1/collections/[csn]/[anchor]', () => {
 			some: "value"
 		})
 	})
+
+	it('responds with replaced nft.private_data variables', async () => {
+		const wallet = await ctx.db.wallet.create({
+			data: {
+				address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' // this is the first hardhat testing wallet
+			}
+		})
+
+		const contract = await ctx.db.contract.create({
+			data: {
+				csn: 'BEEF',
+				name: 'Deadbeef',
+				address: '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
+				network: 'local-test',
+				settings: {
+					NFT_NAME: "DigitalSoul #[MY_PRIVATE_VALUE]", // Tests the contract-wise settings including Variables
+					NFT_DESCRIPTION: "Contract is deployed at [CONTRACT_ADDRESS] as '[COLLECTION_NAME]'" // 
+				},
+				owner: {
+					connect: {
+						id: wallet.id
+					}
+				}
+			}
+		})
+
+		const nft = await ctx.db.NFT.create({
+			data: {
+				slid: 'TEST',
+				anchor: '0x505def45449ab0da5a5d58456298c4e2634c698cccc30f6259e3c6695c664731',
+				metadata: {
+					"some": "value",
+					"attributes": [{
+						"type": "SuperFancy",
+						"value": "[MY_PRIVATE_VALUE]"
+					}]
+				},
+				privateData: {
+					"my_private_value": "002"
+				},
+				contract: {
+					connect: {
+						id: contract.id
+					}
+				}
+			}
+		})
+
+		const { req, res } = createMocks({
+			method: 'GET',
+			query: {
+				csn: 'BEEF',
+				anchor: '0x505def45449ab0da5a5d58456298c4e2634c698cccc30f6259e3c6695c664731'
+			}
+		})
+
+		await api(req, res)
+		const data = await res._getJSONData()
+
+		expect(data).toEqual({
+			name: 'DigitalSoul #002',
+			description: "Contract is deployed at 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF as 'Deadbeef'",
+			some: "value",
+			attributes: [{
+				type: "SuperFancy",
+				value: "002"
+			}]
+		})
+	})
 })

--- a/__tests__/api/v1/collections/index.test.js
+++ b/__tests__/api/v1/collections/index.test.js
@@ -98,7 +98,7 @@ describe('/api/v1/collections/[csn]/[anchor]', () => {
 	})
 
 	describe('private data', () => {
-		it('responds with the variable name when the private data is not set', async () => {
+		it('replaces variable with empty string when private data is not set', async () => {
 			const wallet = await ctx.db.wallet.create({
 				data: {
 					address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' // this is the first hardhat testing wallet
@@ -132,7 +132,8 @@ describe('/api/v1/collections/[csn]/[anchor]', () => {
 						"attributes": [{
 							"type": "SuperFancy",
 							"value": "[MY_PRIVATE_VALUE]"
-						}]
+						}],
+						"an_array": ["PRESERVE_THIS"] // This is NOT a variable and needs to stay untouched preserved
 					},
 					privateData: {
 						"something-else": "002"
@@ -157,78 +158,13 @@ describe('/api/v1/collections/[csn]/[anchor]', () => {
 			const data = await res._getJSONData()
 
 			expect(data).toEqual({
-				name: 'DigitalSoul #[MY_PRIVATE_VALUE]',
+				name: 'DigitalSoul #',
 				description: "Contract is deployed at 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF as 'Deadbeef'",
 				some: "value",
+				an_array: ["PRESERVE_THIS"],
 				attributes: [{
 					type: "SuperFancy",
-					value: "[MY_PRIVATE_VALUE]"
-				}]
-			})
-		})
-
-		it('responds with the variable name when the private data is not set', async () => {
-			const wallet = await ctx.db.wallet.create({
-				data: {
-					address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' // this is the first hardhat testing wallet
-				}
-			})
-
-			const contract = await ctx.db.contract.create({
-				data: {
-					csn: 'BEEF',
-					name: 'Deadbeef',
-					address: '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
-					network: 'local-test',
-					settings: {
-						NFT_NAME: "DigitalSoul #[MY_PRIVATE_VALUE]", // Tests the contract-wise settings including Variables
-						NFT_DESCRIPTION: "Contract is deployed at [CONTRACT_ADDRESS] as '[COLLECTION_NAME]'" //
-					},
-					owner: {
-						connect: {
-							id: wallet.id
-						}
-					}
-				}
-			})
-
-			const nft = await ctx.db.NFT.create({
-				data: {
-					slid: 'TEST',
-					anchor: '0x505def45449ab0da5a5d58456298c4e2634c698cccc30f6259e3c6695c664731',
-					metadata: {
-						"some": "value",
-						"attributes": [{
-							"type": "SuperFancy",
-							"value": "[MY_PRIVATE_VALUE]"
-						}]
-					},
-					contract: {
-						connect: {
-							id: contract.id
-						}
-					}
-				}
-			})
-
-			const { req, res } = createMocks({
-				method: 'GET',
-				query: {
-					csn: 'BEEF',
-					anchor: '0x505def45449ab0da5a5d58456298c4e2634c698cccc30f6259e3c6695c664731'
-				}
-			})
-
-			await api(req, res)
-			const data = await res._getJSONData()
-
-			expect(data).toEqual({
-				name: 'DigitalSoul #[MY_PRIVATE_VALUE]',
-				description: "Contract is deployed at 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF as 'Deadbeef'",
-				some: "value",
-				attributes: [{
-					type: "SuperFancy",
-					value: "[MY_PRIVATE_VALUE]"
+					value: ""
 				}]
 			})
 		})

--- a/__tests__/api/v1/collections/index.test.js
+++ b/__tests__/api/v1/collections/index.test.js
@@ -167,6 +167,72 @@ describe('/api/v1/collections/[csn]/[anchor]', () => {
 			})
 		})
 
+		it('responds with the variable name when the private data is not set', async () => {
+			const wallet = await ctx.db.wallet.create({
+				data: {
+					address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' // this is the first hardhat testing wallet
+				}
+			})
+
+			const contract = await ctx.db.contract.create({
+				data: {
+					csn: 'BEEF',
+					name: 'Deadbeef',
+					address: '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
+					network: 'local-test',
+					settings: {
+						NFT_NAME: "DigitalSoul #[MY_PRIVATE_VALUE]", // Tests the contract-wise settings including Variables
+						NFT_DESCRIPTION: "Contract is deployed at [CONTRACT_ADDRESS] as '[COLLECTION_NAME]'" //
+					},
+					owner: {
+						connect: {
+							id: wallet.id
+						}
+					}
+				}
+			})
+
+			const nft = await ctx.db.NFT.create({
+				data: {
+					slid: 'TEST',
+					anchor: '0x505def45449ab0da5a5d58456298c4e2634c698cccc30f6259e3c6695c664731',
+					metadata: {
+						"some": "value",
+						"attributes": [{
+							"type": "SuperFancy",
+							"value": "[MY_PRIVATE_VALUE]"
+						}]
+					},
+					contract: {
+						connect: {
+							id: contract.id
+						}
+					}
+				}
+			})
+
+			const { req, res } = createMocks({
+				method: 'GET',
+				query: {
+					csn: 'BEEF',
+					anchor: '0x505def45449ab0da5a5d58456298c4e2634c698cccc30f6259e3c6695c664731'
+				}
+			})
+
+			await api(req, res)
+			const data = await res._getJSONData()
+
+			expect(data).toEqual({
+				name: 'DigitalSoul #[MY_PRIVATE_VALUE]',
+				description: "Contract is deployed at 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF as 'Deadbeef'",
+				some: "value",
+				attributes: [{
+					type: "SuperFancy",
+					value: "[MY_PRIVATE_VALUE]"
+				}]
+			})
+		})
+
 		it('responds with replaced nft.private_data variables', async () => {
 			const wallet = await ctx.db.wallet.create({
 				data: {

--- a/__tests__/api/v1/collections/index.test.js
+++ b/__tests__/api/v1/collections/index.test.js
@@ -54,7 +54,7 @@ describe('/api/v1/collections/[csn]/[anchor]', () => {
 				network: 'local-test',
 				settings: {
 					NFT_NAME: "DigitalSoul [ANCHOR_SHORT]", // Tests the contract-wise settings including Variables
-					NFT_DESCRIPTION: "Contract is deployed at [CONTRACT_ADDRESS] as '[COLLECTION_NAME]'" // 
+					NFT_DESCRIPTION: "Contract is deployed at [CONTRACT_ADDRESS] as '[COLLECTION_NAME]'" //
 				},
 				owner: {
 					connect: {

--- a/__tests__/api/v1/collections/index.test.js
+++ b/__tests__/api/v1/collections/index.test.js
@@ -97,72 +97,143 @@ describe('/api/v1/collections/[csn]/[anchor]', () => {
 		})
 	})
 
-	it('responds with replaced nft.private_data variables', async () => {
-		const wallet = await ctx.db.wallet.create({
-			data: {
-				address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' // this is the first hardhat testing wallet
-			}
-		})
+	describe('private data', () => {
+		it('responds with the variable name when the private data is not set', async () => {
+			const wallet = await ctx.db.wallet.create({
+				data: {
+					address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' // this is the first hardhat testing wallet
+				}
+			})
 
-		const contract = await ctx.db.contract.create({
-			data: {
-				csn: 'BEEF',
-				name: 'Deadbeef',
-				address: '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
-				network: 'local-test',
-				settings: {
-					NFT_NAME: "DigitalSoul #[MY_PRIVATE_VALUE]", // Tests the contract-wise settings including Variables
-					NFT_DESCRIPTION: "Contract is deployed at [CONTRACT_ADDRESS] as '[COLLECTION_NAME]'" // 
-				},
-				owner: {
-					connect: {
-						id: wallet.id
+			const contract = await ctx.db.contract.create({
+				data: {
+					csn: 'BEEF',
+					name: 'Deadbeef',
+					address: '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
+					network: 'local-test',
+					settings: {
+						NFT_NAME: "DigitalSoul #[MY_PRIVATE_VALUE]", // Tests the contract-wise settings including Variables
+						NFT_DESCRIPTION: "Contract is deployed at [CONTRACT_ADDRESS] as '[COLLECTION_NAME]'" //
+					},
+					owner: {
+						connect: {
+							id: wallet.id
+						}
 					}
 				}
-			}
-		})
+			})
 
-		const nft = await ctx.db.NFT.create({
-			data: {
-				slid: 'TEST',
-				anchor: '0x505def45449ab0da5a5d58456298c4e2634c698cccc30f6259e3c6695c664731',
-				metadata: {
-					"some": "value",
-					"attributes": [{
-						"type": "SuperFancy",
-						"value": "[MY_PRIVATE_VALUE]"
-					}]
-				},
-				privateData: {
-					"my_private_value": "002"
-				},
-				contract: {
-					connect: {
-						id: contract.id
+			const nft = await ctx.db.NFT.create({
+				data: {
+					slid: 'TEST',
+					anchor: '0x505def45449ab0da5a5d58456298c4e2634c698cccc30f6259e3c6695c664731',
+					metadata: {
+						"some": "value",
+						"attributes": [{
+							"type": "SuperFancy",
+							"value": "[MY_PRIVATE_VALUE]"
+						}]
+					},
+					privateData: {
+						"something-else": "002"
+					},
+					contract: {
+						connect: {
+							id: contract.id
+						}
 					}
 				}
-			}
+			})
+
+			const { req, res } = createMocks({
+				method: 'GET',
+				query: {
+					csn: 'BEEF',
+					anchor: '0x505def45449ab0da5a5d58456298c4e2634c698cccc30f6259e3c6695c664731'
+				}
+			})
+
+			await api(req, res)
+			const data = await res._getJSONData()
+
+			expect(data).toEqual({
+				name: 'DigitalSoul #[MY_PRIVATE_VALUE]',
+				description: "Contract is deployed at 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF as 'Deadbeef'",
+				some: "value",
+				attributes: [{
+					type: "SuperFancy",
+					value: "[MY_PRIVATE_VALUE]"
+				}]
+			})
 		})
 
-		const { req, res } = createMocks({
-			method: 'GET',
-			query: {
-				csn: 'BEEF',
-				anchor: '0x505def45449ab0da5a5d58456298c4e2634c698cccc30f6259e3c6695c664731'
-			}
-		})
+		it('responds with replaced nft.private_data variables', async () => {
+			const wallet = await ctx.db.wallet.create({
+				data: {
+					address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' // this is the first hardhat testing wallet
+				}
+			})
 
-		await api(req, res)
-		const data = await res._getJSONData()
+			const contract = await ctx.db.contract.create({
+				data: {
+					csn: 'BEEF',
+					name: 'Deadbeef',
+					address: '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
+					network: 'local-test',
+					settings: {
+						NFT_NAME: "DigitalSoul #[MY_PRIVATE_VALUE]", // Tests the contract-wise settings including Variables
+						NFT_DESCRIPTION: "Contract is deployed at [CONTRACT_ADDRESS] as '[COLLECTION_NAME]'" //
+					},
+					owner: {
+						connect: {
+							id: wallet.id
+						}
+					}
+				}
+			})
 
-		expect(data).toEqual({
-			name: 'DigitalSoul #002',
-			description: "Contract is deployed at 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF as 'Deadbeef'",
-			some: "value",
-			attributes: [{
-				type: "SuperFancy",
-				value: "002"
-			}]
+			const nft = await ctx.db.NFT.create({
+				data: {
+					slid: 'TEST',
+					anchor: '0x505def45449ab0da5a5d58456298c4e2634c698cccc30f6259e3c6695c664731',
+					metadata: {
+						"some": "value",
+						"attributes": [{
+							"type": "SuperFancy",
+							"value": "[MY_PRIVATE_VALUE]"
+						}]
+					},
+					privateData: {
+						"my_private_value": "002"
+					},
+					contract: {
+						connect: {
+							id: contract.id
+						}
+					}
+				}
+			})
+
+			const { req, res } = createMocks({
+				method: 'GET',
+				query: {
+					csn: 'BEEF',
+					anchor: '0x505def45449ab0da5a5d58456298c4e2634c698cccc30f6259e3c6695c664731'
+				}
+			})
+
+			await api(req, res)
+			const data = await res._getJSONData()
+
+			expect(data).toEqual({
+				name: 'DigitalSoul #002',
+				description: "Contract is deployed at 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF as 'Deadbeef'",
+				some: "value",
+				attributes: [{
+					type: "SuperFancy",
+					value: "002"
+				}]
+			})
 		})
 	})
 })

--- a/__tests__/lib/utils/fillVariablesIntoString.test.js
+++ b/__tests__/lib/utils/fillVariablesIntoString.test.js
@@ -12,13 +12,13 @@ describe('utils.fillVariablesIntoString', () => {
 		expect(actual).toEqual(expected)
 	})
 
-	it('replace the value with the variable name when variable does not exist', () => {
+	it('replace the value with empty string when variable does not exist', () => {
 		const variables = {
 			"MY_VALUE": "123"
 		}
 
 		const str = "Hello [SOMETHING]"
-		const expected = "Hello [SOMETHING]"
+		const expected = "Hello "
 		const actual = fillVariablesIntoString(str, variables)
 		expect(actual).toEqual(expected)
 	})

--- a/__tests__/lib/utils/fillVariablesIntoString.test.js
+++ b/__tests__/lib/utils/fillVariablesIntoString.test.js
@@ -1,0 +1,82 @@
+import { fillVariablesIntoString } from '@/lib/utils'
+
+describe('utils.fillVariablesIntoString', () => {
+	it('fills variables into a string', () => {
+		const variables = {
+			"MY_VALUE": "123"
+		}
+
+		const str = "Hello [MY_VALUE]"
+		const expected = "Hello 123"
+		const actual = fillVariablesIntoString(str, variables)
+		expect(actual).toEqual(expected)
+	})
+
+	it('replace the value with the variable name when variable does not exist', () => {
+		const variables = {
+			"MY_VALUE": "123"
+		}
+
+		const str = "Hello [SOMETHING]"
+		const expected = "Hello [SOMETHING]"
+		const actual = fillVariablesIntoString(str, variables)
+		expect(actual).toEqual(expected)
+	})
+
+	it('replaces multiple variables', () => {
+		const variables = {
+			"MY_VALUE": "123",
+			"MY_OTHER_VALUE": "456"
+		}
+
+		const str = "Hello [MY_VALUE] and [MY_OTHER_VALUE]"
+		const expected = "Hello 123 and 456"
+		const actual = fillVariablesIntoString(str, variables)
+		expect(actual).toEqual(expected)
+	})
+
+	it('replaces multiple variables with the same name', () => {
+		const variables = {
+			"MY_VALUE": "123",
+			"MY_OTHER_VALUE": "456"
+		}
+
+		const str = "Hello [MY_VALUE] and [MY_VALUE]"
+		const expected = "Hello 123 and 123"
+		const actual = fillVariablesIntoString(str, variables)
+		expect(actual).toEqual(expected)
+	})
+
+	it('replaces variables in objects', () => {
+		const variables = {
+			"MY_VALUE": "123",
+			"MY_OTHER_VALUE": "456"
+		}
+
+		const obj = {
+			"key": "Hello [MY_VALUE] and [MY_OTHER_VALUE]"
+		}
+
+		const expected = {
+			"key": "Hello 123 and 456"
+		}
+
+		const actual = fillVariablesIntoString(obj, variables)
+		expect(actual).toEqual(expected)
+	})
+
+	it('replaces variables in an array', () => {
+		const variables = {
+			"MY_VALUE": "123",
+			"MY_OTHER_VALUE": "456"
+		}
+
+		const arr = [
+			"Hello [MY_VALUE] and [MY_OTHER_VALUE]"
+		]
+
+		expect(fillVariablesIntoString(arr, variables)).toEqual([
+			'Hello 123 and 456'
+		])
+	})
+})

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,9 +40,33 @@ export function pp(json) {
 
 // Pass "Duck [ANCHOR_SHORT]", {"ANCHOR_SHORT": "0x123..abc"} and it will return "Duck 0x123...abc"
 export function fillVariablesIntoString(text, variables) {
-    return text.replace(/\[([^\]]+)\]/g, function(_, variable) {
-        return variables[variable] || `[${variable}]`;
-    });
+    // Function to recursively process strings or objects
+    const process = (item) => {
+        if (typeof item === 'string') {
+            // Replace variables in the string
+            return item.replace(/\[([^\]]+)\]/g, function(_, variable) {
+                return variables[variable] || `[${variable}]`;
+            });
+        } else if (typeof item === 'object' && item !== null) {
+            // Process each property of the object
+            for (const key in item) {
+                item[key] = process(item[key]);
+            }
+        }
+        return item;
+    };
+
+    // Parse the text if it's a JSON string, otherwise process it directly
+	// This is needed to account for variables inside arrays in a stringified json-object.
+	// A typical occurance is the attributes: [{..}, {..}] array
+    try {
+        const parsed = JSON.parse(text);
+        return JSON.stringify(process(parsed));
+    } catch (e) {
+		// using catch for program logic is not ideal, but we apply this function typically to JSON-Objects.
+		// Maybe refactored later on
+        return process(text);
+    }
 }
 
 export function addressMatch(a, b) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -53,6 +53,7 @@ export function fillVariablesIntoString(text, variables) {
                 item[key] = process(item[key]);
             }
         }
+
         return item;
     };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -45,7 +45,7 @@ export function fillVariablesIntoString(text, variables) {
         if (typeof item === 'string') {
             // Replace variables in the string
             return item.replace(/\[([^\]]+)\]/g, function(_, variable) {
-                return variables[variable] || `[${variable}]`;
+                return variables[variable] || "";
             });
         } else if (typeof item === 'object' && item !== null) {
             // Process each property of the object

--- a/pages/api/v1/collections/[csn]/[anchor]/index.js
+++ b/pages/api/v1/collections/[csn]/[anchor]/index.js
@@ -59,7 +59,7 @@ function fillMetadataVariables(metadata, nft) {
 	}
 
 	// Add private data as variables, convert them to upper-case
-	if(nft.privateData) {
+	if (nft.privateData) {
 		Object.keys(nft.privateData).forEach(key => {
 			variables[key.toUpperCase()] = nft.privateData[key]
 		})

--- a/pages/api/v1/collections/[csn]/[anchor]/index.js
+++ b/pages/api/v1/collections/[csn]/[anchor]/index.js
@@ -29,7 +29,7 @@ function generateCollectionMetadata(nft) {
 function fillMetadataVariables(metadata, nft) {
 	// TODO proper documentation and easier configuration
 	// Hardcoding is certainly not the way to go forward
-	const variables = {
+	let variables = {
 		// ############### Label-Details
 		// This is the anchor in its full length
 		// e.g. 0x96af27ebecfb5fcc4631db56c62a3ba2b3bed954740dddaa36c510580a72a2ec
@@ -56,6 +56,13 @@ function fillMetadataVariables(metadata, nft) {
 		// The smart contract address in short-representation
 		// e.g. 0xa257...f101d
 		'CONTRACT_ADDRESS_SHORT': formatAddress(nft.contract.address)
+	}
+
+	// Add private data as variables, convert them to upper-case
+	if(nft.privateData) {
+		Object.keys(nft.privateData).forEach(key => {
+			variables[key.toUpperCase()] = nft.privateData[key]
+		})
 	}
 
 	// The easiest really is to dump metadata to a string and then convert to object again

--- a/prisma/migrations/20231208170038_private_data/migration.sql
+++ b/prisma/migrations/20231208170038_private_data/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "nfts" ADD COLUMN     "private_data" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -63,6 +63,7 @@ model NFT {
   anchor   String
   slid     String
   metadata Json?
+  privateData Json? @map(name: "private_data")
 
   createdAt  DateTime @default(now()) @map(name: "created_at")
   updatedAt  DateTime @default(now()) @map(name: "updated_at")


### PR DESCRIPTION
The backend for #71 :
- Add nft.private_data column
- Allow variable-access from MetaData to all nft.private_data. 
- Added a test-case, accessing a private_data value from the Contract-Settings (in the NFT-Name) as well as the NFT itself (in the attributes)