### PR TITLE
API for NFT-update, Fix landing page

### DIFF
--- a/pages/api/internal/contract/[csn]/fetchNfts.js
+++ b/pages/api/internal/contract/[csn]/fetchNfts.js
@@ -1,0 +1,81 @@
+import { getServerSession } from 'next-auth/next'
+import { authOptions } from '@/pages/api/auth/[...nextauth]'
+import prisma from '@/lib/prisma'
+import MetaAnchor from '@/lib/api.metaanchor.io'
+
+const allowedMethods = ['GET']
+
+// TODO MOVE TO UTILS
+export const fetchAnchors = async(api, csn) => {
+	return await api.getAnchors(csn)
+}
+
+export const storeNFTS = async (anchors, contract) => {
+    let createdCount = 0; // Counter for newly created NFTs
+  
+    const nfts = await Promise.all(anchors.map(async (anchor) => {
+      // Check if an NFT with the same slid already exists
+      const existingNFT = await prisma.NFT.findUnique({
+        where: { slid: anchor.slid },
+      });
+  
+      // If it doesn't exist, create a new one
+      if (!existingNFT) {
+        createdCount++; // Increment the counter
+        return await prisma.NFT.create({
+          data: {
+            slid: anchor.slid,
+            anchor: anchor.anchor,
+            metadata: undefined, // per default, do not set any metadata
+            contract: { connect: { id: contract.id } }
+          }
+        });
+      }
+  
+      // If it exists, return existing record
+      return existingNFT;
+    }));
+  
+    // Fetch the total number of NFTs
+    const totalCount = nfts.length
+  
+    return {
+      nfts,        // The array of NFTs (both newly created and existing)
+      createdCount,   // Number of newly created NFTs
+      totalCount       // Total number of NFTs in the database
+    };
+  };
+
+
+export default async function handle(req, res) {
+	const session = await getServerSession(req, res, authOptions)
+	if (!session) {
+		return res.status(401).json({ message: 'Unauthorized' })
+	}
+
+	if (!allowedMethods.includes(req.method) || req.method == 'OPTIONS') {
+		return res.status(405).json({ message: 'Method not allowed.' })
+	}
+
+
+	const { csn } = req.query
+	const config = await prisma.config.findFirst()
+    const api = new MetaAnchor({
+		apiKey: config.apiKey,
+		baseUrl: process.env.METAANCHOR_API_URL
+	})
+	
+    const { data: anchors } = await fetchAnchors(api, csn)
+    const contract = await prisma.contract.findFirst({
+        where: {
+            csn: csn
+        }
+    })
+
+    if (anchors.length) {
+        const {nfts, createdCount, totalCount} = await storeNFTS(anchors, contract)
+        console.log(`Added ${createdCount} NFTs of ${csn} to total ${totalCount} NFTs`)
+    }
+
+	return res.json({ ...contract })
+}

--- a/pages/landing.js
+++ b/pages/landing.js
@@ -152,6 +152,8 @@ const LandingNFT = ({ nft, noData, avSip, errorMsg, wallet, assetData, props }) 
 	const [ownershipStatus, setOwnershipStatus] = useState(
 		addressMatch(assetData?.owner, wallet?.address) ? OWNER_STATUS : RECEIVING_STATUS
 	)
+	const [assetDataState, setAssetDataState] = useState(assetData);
+
 
 	const CurrentCard = useCallback(() => {
 		switch (ownershipStatus) {
@@ -159,15 +161,15 @@ const LandingNFT = ({ nft, noData, avSip, errorMsg, wallet, assetData, props }) 
 			// where the user can upload an image, as soon as uploaded, forward to RECEIVING_STATUS
 			// and actually claim it
 			case OWNER_STATUS:
-				return (<OwnerCardView wallet={wallet} assetData={assetData} />)
+				return (<OwnerCardView wallet={wallet} assetData={assetDataState} />)
 			case RECEIVING_STATUS:
-				return (<ReceivingCardView wallet={wallet} assetData={assetData} />)
+				return (<ReceivingCardView wallet={wallet} assetData={assetDataState} />)
 			case LOST_STATUS:
 				return (<LostCardView wallet={wallet} newOwner={newOwner} />)
 			default:
-				return (<ReceivingCardView wallet={wallet} assetData={assetData} />)
+				return (<ReceivingCardView wallet={wallet} assetData={assetDataState} />)
 		}
-	}, [ownershipStatus, nft, wallet, assetData, newOwner])
+	}, [ownershipStatus, nft, wallet, assetData, newOwner, assetDataState])
 
 	const nftWasClaimed = (result) => {
 		if (addressMatch(wallet.address, result.owner)) {
@@ -214,7 +216,8 @@ const LandingNFT = ({ nft, noData, avSip, errorMsg, wallet, assetData, props }) 
 		const data = response.json()
 
 		if (response.ok) {
-			await poll(verifySipToken, nftWasClaimed, 3000)
+			const result = await poll(verifySipToken, nftWasClaimed, 3000)
+			setAssetDataState(result); // Update the asset data state
 			setOwnershipStatus(OWNER_STATUS)
 		} else {
 			setError('Something went wrong when trying to claim NFT')
@@ -223,6 +226,7 @@ const LandingNFT = ({ nft, noData, avSip, errorMsg, wallet, assetData, props }) 
 
 	const checkNFTOwnership = async () => {
 		const result = await poll(verifySipToken, nftWasTransfered, 3000)
+		setAssetDataState(result); // Update the asset data state
 		setNewOwner(result.owner)
 		setOwnershipStatus(LOST_STATUS)
 	}
@@ -253,7 +257,7 @@ const LandingNFT = ({ nft, noData, avSip, errorMsg, wallet, assetData, props }) 
 
 					{!error && (
 						<div className="flex justify-center py-2 flex-col">
-							<CurrentCard nft={nft} assetData={assetData} wallet={wallet} />
+							<CurrentCard nft={nft} assetData={assetDataState} wallet={wallet} />
 						</div>
 					)}
 				</main>


### PR DESCRIPTION
This contains two features:
- Intermediate solution: An internal API to fetch NFTs from the MetaAnchor-API at any time. This is needed, when new labels are added to a Smart Contract. There is no Frontend, because this shall later be handled through the push-endpoint (#8 )
- Bugfix for landing-page. 
   - On the mint / first claim of any NFT, the assetData was not updated in the OwnerCard etc, resulting in the image not being shown (#73 ) due to lacking tokenURI. 
   - Making `assetData` a state variable resolves the issue. Note we do NOT update the `assetDataState` variable in the polling function, because this causes the website to re-render with every poll.

**Note to self:**
This shall be merged as two commits, as it contains two features.