### PR TITLE
api: makePublicEndpoint helper for CORS

### DIFF
--- a/__tests__/api/v1/collections/index.test.js
+++ b/__tests__/api/v1/collections/index.test.js
@@ -90,6 +90,7 @@ describe('/api/v1/collections/[csn]/[anchor]', () => {
 		})
 
 		await api(req, res)
+		expect(await res.getHeader('access-control-allow-origin')).toEqual('*') // CORS enabled
 		const data = await res._getJSONData()
 
 		expect(data).toEqual({
@@ -157,6 +158,7 @@ describe('/api/v1/collections/[csn]/[anchor]', () => {
 			})
 
 			await api(req, res)
+			expect(await res.getHeader('access-control-allow-origin')).toEqual('*') // CORS enabled
 			const data = await res._getJSONData()
 
 			expect(data).toEqual({
@@ -227,6 +229,8 @@ describe('/api/v1/collections/[csn]/[anchor]', () => {
 			})
 
 			await api(req, res)
+			expect(await res.getHeader('access-control-allow-origin')).toEqual('*') // CORS enabled
+
 			const data = await res._getJSONData()
 
 			expect(data).toEqual({

--- a/lib/apiHelpers.js
+++ b/lib/apiHelpers.js
@@ -1,0 +1,26 @@
+// utils/apiHelpers.js
+import NextCors from "nextjs-cors";
+
+// Utility function to prepare global API settings
+async function makePublicEndpoint(req, res, allowedMethods = ["GET"]) {
+	const allowedMethodsWithOptions = ["OPTIONS", ...allowedMethods];
+
+	// Initialize CORS with common settings
+	await NextCors(req, res, {
+		methods: allowedMethodsWithOptions, // Options shall always be allowed
+		origin: "*", // Adjust according to your needs
+		optionsSuccessStatus: 200,
+	});
+
+	// Check for allowed HTTP methods
+	if (!allowedMethodsWithOptions.includes(req.method)) {
+		res.status(405).json({
+			message: `Method not allowed.`,
+			hint: `Allowed methods: ${allowedMethodsWithOptions}`,
+		});
+		return false;
+	}
+	return true;
+}
+
+export { makePublicEndpoint };

--- a/lib/apiHelpers.js
+++ b/lib/apiHelpers.js
@@ -1,6 +1,20 @@
 // utils/apiHelpers.js
 import NextCors from "nextjs-cors";
 
+async function checkAllowedMethods(req, res, allowedMethods) {
+	const allowedMethodsWithOptions = ["OPTIONS", ...allowedMethods]; // OPTIONS is always allowed
+	// Check for allowed HTTP methods
+	if (!allowedMethodsWithOptions.includes(req.method)) {
+		res.status(405).json({
+			message: `Method not allowed.`,
+			hint: `Allowed methods: ${allowedMethodsWithOptions}`,
+		});
+		return false;
+	}
+	return true;
+
+}
+
 // Utility function to prepare global API settings
 async function makePublicEndpoint(req, res, allowedMethods = ["GET"]) {
 	const allowedMethodsWithOptions = ["OPTIONS", ...allowedMethods];
@@ -12,15 +26,8 @@ async function makePublicEndpoint(req, res, allowedMethods = ["GET"]) {
 		optionsSuccessStatus: 200,
 	});
 
-	// Check for allowed HTTP methods
-	if (!allowedMethodsWithOptions.includes(req.method)) {
-		res.status(405).json({
-			message: `Method not allowed.`,
-			hint: `Allowed methods: ${allowedMethodsWithOptions}`,
-		});
-		return false;
-	}
-	return true;
+	return checkAllowedMethods(req, res, allowedMethods)
 }
 
 export { makePublicEndpoint };
+export { checkAllowedMethods };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "nanoid": "^5.0.3",
     "next": "13.4.18",
     "next-auth": "^4.23.1",
+    "nextjs-cors": "^2.2.0",
     "node-mocks-http": "^1.13.0",
     "paseto": "^3.1.4",
     "pg": "^8.11.3",

--- a/pages/api/internal/assets/[csn]/[anchor]/[assetType]/index.js
+++ b/pages/api/internal/assets/[csn]/[anchor]/[assetType]/index.js
@@ -2,7 +2,7 @@ import { getServerSession } from "next-auth/next"
 import { authOptions } from "@/pages/api/auth/[...nextauth]"
 
 import path from 'path'
-
+import { checkAllowedMethods } from "@/lib/apiHelpers"
 import prisma from '@/lib/prisma'
 
 import formidable from 'formidable-serverless'
@@ -112,10 +112,8 @@ export default async function handle(req, res) {
 		return res.status(401).json({ message: 'Unauthorized' })
 	}
 
-	// TODO: Move this somewhere else, probably as a utility function
-	if (!allowedMethods.includes(req.method) || req.method == 'OPTIONS') {
-		return res.status(405).json({ message: 'Method not allowed.' })
-	}
+	if (!await checkAllowedMethods(req, res, allowedMethods)) return;
+
 
 	const { csn, anchor, assetType } = req.query
 	const wallet = session.wallet

--- a/pages/api/internal/contract/[csn]/edit.js
+++ b/pages/api/internal/contract/[csn]/edit.js
@@ -1,6 +1,7 @@
 import { getServerSession } from 'next-auth/next'
 import { authOptions } from '@/pages/api/auth/[...nextauth]'
 import prisma from '@/lib/prisma'
+import { checkAllowedMethods } from '@/lib/apiHelpers';
 
 const allowedMethods = ['PUT']
 
@@ -10,9 +11,7 @@ export default async function handle(req, res) {
 		return res.status(401).json({ message: 'Unauthorized' })
 	}
 
-	if (!allowedMethods.includes(req.method) || req.method == 'OPTIONS') {
-		return res.status(405).json({ message: 'Method not allowed.' })
-	}
+	if (!await checkAllowedMethods(req, res, allowedMethods)) return;
 
 	const { csn } = req.query
 	const { contractSettings: rawContractSettings } = req.body

--- a/pages/api/internal/contract/[csn]/fetchNfts.js
+++ b/pages/api/internal/contract/[csn]/fetchNfts.js
@@ -2,6 +2,8 @@ import { getServerSession } from 'next-auth/next'
 import { authOptions } from '@/pages/api/auth/[...nextauth]'
 import prisma from '@/lib/prisma'
 import MetaAnchor from '@/lib/api.metaanchor.io'
+import { checkAllowedMethods } from '@/lib/apiHelpers';
+
 
 const allowedMethods = ['GET']
 
@@ -53,10 +55,7 @@ export default async function handle(req, res) {
 		return res.status(401).json({ message: 'Unauthorized' })
 	}
 
-	if (!allowedMethods.includes(req.method) || req.method == 'OPTIONS') {
-		return res.status(405).json({ message: 'Method not allowed.' })
-	}
-
+  if (!await checkAllowedMethods(req, res, allowedMethods)) return;
 
 	const { csn } = req.query
 	const config = await prisma.config.findFirst()

--- a/pages/api/internal/contracts/index.js
+++ b/pages/api/internal/contracts/index.js
@@ -1,10 +1,9 @@
 import { getServerSession } from "next-auth/next"
 import { authOptions } from "@/pages/api/auth/[...nextauth]"
-
 import prisma from '@/lib/prisma'
-import { Prisma } from '@prisma/client'
 import MetaAnchor from '@/lib/api.metaanchor.io'
 import { fetchAnchors, storeNFTS } from "../contract/[csn]/fetchNfts"
+import { checkAllowedMethods } from '@/lib/apiHelpers';
 
 const allowedMethods = ['POST']
 
@@ -62,13 +61,9 @@ export default async function handle(req, res) {
 	const session = await getServerSession(req, res, authOptions)
 	if (!session) {
 		return res.status(401).json({ message: 'Unauthorized' })
-	}
-
-	let errorMsg
-
-	if (!allowedMethods.includes(req.method) || req.method == 'OPTIONS') {
-		return res.status(405).json({ message: 'Method not allowed.' })
-	}
+	}	
+	
+	if (!await checkAllowedMethods(req, res, allowedMethods)) return;
 
 	const config = await prisma.config.findFirst()
 

--- a/pages/api/internal/landing/claim.js
+++ b/pages/api/internal/landing/claim.js
@@ -1,14 +1,12 @@
 import prisma from '@/lib/prisma'
-import { Prisma } from '@prisma/client'
 import MetaAnchor from '@/lib/api.metaanchor.io'
+import { checkAllowedMethods } from '@/lib/apiHelpers';
 
 const allowedMethods = ['POST']
 
 export default async function handle(req, res) {
 	// TODO: Move this somewhere else, probably as a utility function
-	if (!allowedMethods.includes(req.method) || req.method == 'OPTIONS') {
-		return res.status(405).json({ message: 'Method not allowed.' })
-	}
+	if (!await checkAllowedMethods(req, res, allowedMethods)) return;
 
 	const { avSip, address } = req.body
 

--- a/pages/api/internal/landing/verify.js
+++ b/pages/api/internal/landing/verify.js
@@ -1,15 +1,13 @@
 import prisma from '@/lib/prisma'
-import { Prisma } from '@prisma/client'
 import MetaAnchor from '@/lib/api.metaanchor.io'
+import { checkAllowedMethods } from '@/lib/apiHelpers';
 
 
 const allowedMethods = ['POST']
 
 export default async function handle(req, res) {
 	// TODO: Move this somewhere else, probably as a utility function
-	if (!allowedMethods.includes(req.method) || req.method == 'OPTIONS') {
-		return res.status(405).json({ message: 'Method not allowed.' })
-	}
+	if (!await checkAllowedMethods(req, res, allowedMethods)) return;
 
 	const { avSip } = req.body
 

--- a/pages/api/internal/nft/[csn]/[anchor]/edit.js
+++ b/pages/api/internal/nft/[csn]/[anchor]/edit.js
@@ -1,9 +1,9 @@
 import { getServerSession } from 'next-auth/next'
 import { authOptions } from '@/pages/api/auth/[...nextauth]'
-
 import prisma from '@/lib/prisma'
 import { z } from 'zod'
-import { fromZodError, isValidationErrorLike } from 'zod-validation-error';
+import { fromZodError } from 'zod-validation-error';
+import { checkAllowedMethods } from '@/lib/apiHelpers';
 
 const allowedMethods = ['PUT']
 const metadataSchema = z.object({
@@ -27,11 +27,7 @@ export default async function handle(req, res) {
 		return res.status(401).json({ message: 'Unauthorized' })
 	}
 
-	let errorMsg
-
-	if (!allowedMethods.includes(req.method) || req.method == 'OPTIONS') {
-		return res.status(405).json({ message: 'Method not allowed.' })
-	}
+	if (!await checkAllowedMethods(req, res, allowedMethods)) return;
 
 	const { anchor, csn } = req.query
 	const { metadata: rawMetadata } = req.body

--- a/pages/api/internal/nft/[csn]/[anchor]/index.js
+++ b/pages/api/internal/nft/[csn]/[anchor]/index.js
@@ -1,6 +1,6 @@
 import { getServerSession } from 'next-auth/next'
 import { authOptions } from '@/pages/api/auth/[...nextauth]'
-
+import { checkAllowedMethods } from '@/lib/apiHelpers';
 import prisma from '@/lib/prisma'
 
 const allowedMethods = ['GET']
@@ -11,11 +11,8 @@ export default async function handle(req, res) {
 		return res.status(401).json({ message: 'Unauthorized' })
 	}
 
-	let errorMsg
+	if (!await checkAllowedMethods(req, res, allowedMethods)) return;
 
-	if (!allowedMethods.includes(req.method) || req.method == 'OPTIONS') {
-		return res.status(405).json({ message: 'Method not allowed.' })
-	}
 
 	const { anchor, csn } = req.query
 

--- a/pages/api/internal/nfts/[contractId].js
+++ b/pages/api/internal/nfts/[contractId].js
@@ -1,6 +1,6 @@
 import { getServerSession } from "next-auth/next"
 import { authOptions } from "@/pages/api/auth/[...nextauth]"
-
+import { checkAllowedMethods } from '@/lib/apiHelpers';
 import prisma from '@/lib/prisma'
 
 const allowedMethods = ['GET']
@@ -11,11 +11,8 @@ export default async function handle(req, res) {
 		return res.status(401).json({ message: 'Unauthorized' })
 	}
 
-	let errorMsg
+	if (!await checkAllowedMethods(req, res, allowedMethods)) return;
 
-	if (!allowedMethods.includes(req.method) || req.method == 'OPTIONS') {
-		return res.status(405).json({ message: 'Method not allowed.' })
-	}
 
 	const { contractId } = req.query
 

--- a/pages/api/internal/setup.js
+++ b/pages/api/internal/setup.js
@@ -3,7 +3,7 @@ import { authOptions } from "@/pages/api/auth/[...nextauth]"
 
 import crypto from 'crypto'
 import prisma from '@/lib/prisma'
-import { Prisma } from '@prisma/client'
+import { checkAllowedMethods } from "@/lib/apiHelpers"
 
 const allowedMethods = ['POST']
 
@@ -75,10 +75,7 @@ export default async function handle(req, res) {
 		return res.status(401).json({ message: 'Unauthorized' })
 	}
 
-	// TODO: Move this somewhere else, probably as a utility function
-	if (!allowedMethods.includes(req.method) || req.method == 'OPTIONS') {
-		return res.status(405).json({ message: 'Method not allowed.' })
-	}
+	if (!await checkAllowedMethods(req, res, allowedMethods)) return;
 
 	const { signedMessage, address } = req.body
 	const instanceApiKey = crypto.randomBytes(32).toString('hex')

--- a/pages/api/internal/wallets/[address]/contracts.js
+++ b/pages/api/internal/wallets/[address]/contracts.js
@@ -1,6 +1,6 @@
 import { getServerSession } from "next-auth/next"
 import { authOptions } from "@/pages/api/auth/[...nextauth]"
-
+import { checkAllowedMethods } from '@/lib/apiHelpers';
 import prisma from '@/lib/prisma'
 
 const allowedMethods = ['GET']
@@ -11,9 +11,7 @@ export default async function handle(req, res) {
 		return res.status(401).json({ message: 'Unauthorized' })
 	}
 
-	if (!allowedMethods.includes(req.method) || req.method == 'OPTIONS') {
-		return res.status(405).json({ message: 'Method not allowed.' })
-	}
+	if (!await checkAllowedMethods(req, res, allowedMethods)) return;
 
 	const { address } = req.query
 

--- a/pages/api/internal/wallets/index.js
+++ b/pages/api/internal/wallets/index.js
@@ -1,6 +1,6 @@
 import { getServerSession } from "next-auth/next"
 import { authOptions } from "@/pages/api/auth/[...nextauth]"
-
+import { checkAllowedMethods } from '@/lib/apiHelpers';
 import prisma from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
 
@@ -12,9 +12,8 @@ export default async function handle(req, res) {
 		return res.status(401).json({ message: 'Unauthorized' })
 	}
 
-	if (!allowedMethods.includes(req.method) || req.method == 'OPTIONS') {
-		return res.status(405).json({ message: 'Method not allowed.' })
-	}
+	if (!await checkAllowedMethods(req, res, allowedMethods)) return;
+
 
 	let { address } = req.body
 	address = address?.toLowerCase()

--- a/pages/api/v1/assets/[...assetHash].js
+++ b/pages/api/v1/assets/[...assetHash].js
@@ -1,21 +1,22 @@
 import express from 'express';
 import {fileTypeFromBuffer} from 'file-type';
 import {readChunk} from 'read-chunk';
-import fs from 'fs';
 import path from 'path';
-
+import { makePublicEndpoint} from '@/lib/apiHelpers';
 export const config = {
   api: { externalResolver: true }
 };
 
 const handler = express();
 
+
 // Middleware to determine and set the MIME type
-async function setMimeType(req, res, next) {
+async function setHeaders(req, res, next) {
+  if(!await makePublicEndpoint(req, res, ['GET'])) return;
+
   const filePath = path.join(process.env.STORAGE_DIR, req.path);
 
   try {
-	
 	// Best-practice from docs	https://www.npmjs.com/package/file-type
 	const buffer = await readChunk(filePath, {length: 4100});
 	const fileTypeResult = await fileTypeFromBuffer(buffer);
@@ -33,6 +34,6 @@ async function setMimeType(req, res, next) {
   next();
 }
 
-handler.use(['/api/v1/assets', '/assets'], setMimeType, express.static(process.env.STORAGE_DIR));
+handler.use(['/api/v1/assets', '/assets'], setHeaders, express.static(process.env.STORAGE_DIR));
 
 export default handler;

--- a/pages/api/v1/collections/[csn]/[anchor]/index.js
+++ b/pages/api/v1/collections/[csn]/[anchor]/index.js
@@ -1,6 +1,6 @@
 import prisma from '@/lib/prisma'
-import { Prisma } from '@prisma/client'
 import { formatAddress, fillVariablesIntoString, fixedLengthHexString, nftDefined } from '@/lib/utils'
+import { makePublicEndpoint } from '@/lib/apiHelpers';
 
 const allowedMethods = ['GET']
 
@@ -72,12 +72,8 @@ function fillMetadataVariables(metadata, nft) {
 }
 
 
-
 export default async function handle(req, res) {
-	// TODO: Move this somewhere else, probably as a utility function
-	if (!allowedMethods.includes(req.method) || req.method == 'OPTIONS') {
-		return res.status(405).json({ message: 'Method not allowed.' })
-	}
+	if (!await makePublicEndpoint(req, res, allowedMethods)) return;
 
 	let contract
 	let nft

--- a/yarn.lock
+++ b/yarn.lock
@@ -2787,6 +2787,14 @@ copy-to-clipboard@^3.3.3:
   dependencies:
     toggle-selection "^1.0.6"
 
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 create-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/create-jest/-/create-jest-29.7.0.tgz#a355c5b3cb1e1af02ba177fe7afd7feee49a5320"
@@ -5630,6 +5638,13 @@ next@13.4.18:
     "@next/swc-win32-ia32-msvc" "13.4.18"
     "@next/swc-win32-x64-msvc" "13.4.18"
 
+nextjs-cors@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/nextjs-cors/-/nextjs-cors-2.2.0.tgz#d429e4cd366cc4a26179c5c1f772613ce2e385a5"
+  integrity sha512-FZu/A+L59J4POJNqwXYyCPDvsLDeu5HjSBvytzS6lsrJeDz5cmnH45zV+VoNic0hjaeER9xGaiIjZIWzEHnxQg==
+  dependencies:
+    cors "^2.8.5"
+
 node-abi@^3.3.0:
   version "3.52.0"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.52.0.tgz#ffba0a85f54e552547e5849015f40f9514d5ba7c"
@@ -5727,7 +5742,7 @@ oauth@^0.9.15:
   resolved "https://registry.yarnpkg.com/oauth/-/oauth-0.9.15.tgz#bd1fefaf686c96b75475aed5196412ff60cfb9c1"
   integrity sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==
 
-object-assign@^4.0.1, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -7638,7 +7653,7 @@ valtio@1.11.2:
     proxy-compare "2.5.1"
     use-sync-external-store "1.2.0"
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==


### PR DESCRIPTION
- Adds a makePublicEndpoint helper function, which
  - Verifies allowed HTTP-Methods
  - Adds CORS header (`access-control-allow-origin: *`)
- Use this function for the endpoints
  - `api/v1/collections/[CSN][ANCHOR]` and
  - `api/v1/assets/[assetHash]`  